### PR TITLE
[fix] productId param on production-test page

### DIFF
--- a/src/v2/components/app/App.tsx
+++ b/src/v2/components/app/App.tsx
@@ -105,7 +105,7 @@ class RouteWithTeProvider extends RouteWithGA<{ posId: string; overrideConfig?: 
   };
 
   render() {
-    const { children, posId } = this.props;
+    const { posId } = this.props;
     const overrideConfig = this.props.overrideConfig || {};
     return (
       <RouterHistory>
@@ -118,7 +118,7 @@ class RouteWithTeProvider extends RouteWithGA<{ posId: string; overrideConfig?: 
             >
               <div className="te-site">
                 <Header onLangChange={this.onLangChange} />
-                <div className="site-body">{children}</div>
+                <div className="site-body">{super.render()}</div>
                 <Footer />
               </div>
             </TipserElementsProvider>
@@ -189,7 +189,11 @@ const App = () => {
         posId="5f738fdd023072000132ae3b"
         overrideConfig={{ env: TipserEnv.prod }}
       >
-        <ProductionTest />
+        <ProductionTest defaultProductId="604ab0fe6772862e4b4266b1" />
+      </RouteWithTeProvider>
+
+      <RouteWithTeProvider path={`${url}/staging-test/:productId?`} posId={posId}>
+        <ProductionTest defaultProductId="603f804e3c0fd07f8abb8493" />
       </RouteWithTeProvider>
       <RouteWithTeProvider
         path={`${url}/express-payment`}

--- a/src/v2/views/production-test/production-test.tsx
+++ b/src/v2/views/production-test/production-test.tsx
@@ -1,19 +1,18 @@
 import React, { FC } from 'react';
-import { withRouter } from 'react-router';
+import { useParams } from 'react-router';
 
 import { ProductTile, Cart } from 'tipser-elements-v2/dist/all';
 
-const PRODUCT_ID = '604ab0fe6772862e4b4266b1';
-
-const ProductionTestComponent: FC<any> = ({ match }) => {
-  const { productId } = match.params;
+type Props = {
+  defaultProductId: string;
+};
+export const ProductionTest: FC<Props> = ({ defaultProductId }) => {
+  const { productId } = useParams();
 
   return (
     <div style={{ minHeight: '52vh' }}>
       <Cart />
-      <ProductTile productId={productId || PRODUCT_ID} />
+      <ProductTile productId={productId || defaultProductId} />
     </div>
   );
 };
-
-export const ProductionTest = withRouter(ProductionTestComponent);

--- a/src/v3/components/app/App.tsx
+++ b/src/v3/components/app/App.tsx
@@ -13,7 +13,7 @@ import {
   ProductStyleWithProducts,
   ProductDescription,
   ProductContainer,
-  CartPage
+  CartPage,
 } from '@tipser/tipser-elements/dist/all';
 import Header from '../header';
 import Footer from '../footer';
@@ -108,20 +108,20 @@ class RouteWithTeProvider extends RouteWithGA<{ posId: string; overrideConfig?: 
   };
 
   render() {
-    const { children } = this.props;
+    const { posId } = this.props;
     const overrideConfig = this.props.overrideConfig || {};
     return (
       <RouterHistory>
         {(history) => {
           return (
             <TipserElementsProvider
-              posId={this.props.posId}
+              posId={posId}
               config={{ ...tipserConfig, ...overrideConfig } as any}
               history={history}
             >
               <div className="te-site">
                 <Header onLangChange={this.onLangChange} />
-                <div className="site-body">{children}</div>
+                <div className="site-body">{super.render()}</div>
                 <Footer />
               </div>
             </TipserElementsProvider>
@@ -195,7 +195,11 @@ const App = () => {
         posId="5f738fdd023072000132ae3b"
         overrideConfig={{ env: TipserEnv.prod }}
       >
-        <ProductionTest />
+        <ProductionTest defaultProductId="604ab0fe6772862e4b4266b1" />
+      </RouteWithTeProvider>
+
+      <RouteWithTeProvider path={`${url}/staging-test/:productId?`} posId={posId}>
+        <ProductionTest defaultProductId="603f804e3c0fd07f8abb8493" />
       </RouteWithTeProvider>
       <RouteWithTeProvider
         path={`${url}/express-payment`}

--- a/src/v3/views/production-test/production-test.tsx
+++ b/src/v3/views/production-test/production-test.tsx
@@ -1,19 +1,18 @@
 import React, { FC } from 'react';
-import { withRouter } from 'react-router';
+import { useParams } from 'react-router';
 
 import { ProductTile, CartIcon } from '@tipser/tipser-elements/dist/all';
 
-const PRODUCT_ID = '604ab0fe6772862e4b4266b1';
-
-const ProductionTestComponent: FC<any> = ({ match }) => {
-  const { productId } = match.params;
+type Props = {
+  defaultProductId: string;
+};
+export const ProductionTest: FC<Props> = ({ defaultProductId }) => {
+  const { productId } = useParams();
 
   return (
     <div style={{ minHeight: '52vh' }}>
       <CartIcon />
-      <ProductTile productId={productId || PRODUCT_ID} />
+      <ProductTile productId={productId || defaultProductId} />
     </div>
   );
 };
-
-export const ProductionTest = withRouter(ProductionTestComponent);


### PR DESCRIPTION
`productId` param on production-test page was always `undefined`. I've fixed this problem. Additionally I've added staging-test page (request from CS)